### PR TITLE
set minSdk 29, change repo to mavenCentral, kotlin codestyle and JVM args

### DIFF
--- a/brailleime/src/main/AndroidManifest.xml
+++ b/brailleime/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     package="com.google.android.accessibility.brailleime">
 
   <uses-sdk
-      android:minSdkVersion="23"
+      android:minSdkVersion="29"
       android:targetSdkVersion="30" />
 
   <!-- Required for haptic feedback. -->

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
@@ -21,7 +21,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 }
@@ -33,7 +33,7 @@ android {
         versionName "370044210"
         versionCode 370044210
         manifestPlaceholders = [talkbackMainPermission:talkbackMainPermission]
-        minSdkVersion 26
+        minSdkVersion 29
         targetSdkVersion 30
         testInstrumentationRunner 'android.test.InstrumentationTestRunner'
         multiDexEnabled true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
-android.useAndroidX = true
-android.enableJetifier = true
-org.gradle.jvmargs=-Xms512M -Xmx8G
+android.useAndroidX=true
+android.enableJetifier=true
+android.enableR8.fullMode=true
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+
+kotlin.code.style=official

--- a/shared.gradle
+++ b/shared.gradle
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true
-        minSdkVersion 23
+        minSdkVersion 29
     }
     lintOptions {
         abortOnError false


### PR DESCRIPTION
Not sure if this talkback will be used by more than just GrapheneOS. If so, could drop minSdk a little lower. I just set it to 29 like the Camera app. Android 10.

Use normal memory allocation. I set the Kotlin codestyle to official like other repos in GrapheneOS. R8 full mode should be fine.
jcenter is also a deprecated and old repo. Should be using mavenCentral for updated libs.

Seems to work just fine with typical emulated Pixel 5.

Targeting SDK 31 requires intent changes in the code I haven't bothered to work out relating to IMMUTABILITY flags. That's as far as I know.

Signed-off-by: June <zanthed@riseup.net>