### PR TITLE
Update gradle and force NDK version to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ apply plugin: 'com.android.application'
 
 apply from: 'shared.gradle'
 
+ext {
+    ndkVersion = '23.1.7779620'
+}
+
 dependencies {
     implementation project(':talkback')
 }
@@ -43,6 +47,7 @@ android {
         exclude 'README'
         exclude 'TODO'
     }
+    ndkVersion ndkVersion
     lintOptions {
         checkReleaseBuilds false
         abortOnError false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=9afb3ca688fc12c761a0e9e4321e4d24e977a4a8916c8a768b1fe05ddb4d6b66
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+distributionSha256Sum=23b89f8eac363f5f4b8336e0530c7295c55b728a9caa5268fdd4a532610d5392
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
for some reason Android Studio tries to get an extremely old NDK version (21...).

Signed-off-by: June <june@eridan.me>