### PR TITLE
Drop unsupported Android versions, add Android 12-specific XML for service

### DIFF
--- a/brailleime/src/main/AndroidManifest.xml
+++ b/brailleime/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     package="com.google.android.accessibility.brailleime">
 
   <uses-sdk
-      android:minSdkVersion="26"
+      android:minSdkVersion="28"
       android:targetSdkVersion="31" />
 
   <!-- Required for haptic feedback. -->

--- a/brailleime/src/main/java/com/google/android/accessibility/brailleime/BrailleIme.java
+++ b/brailleime/src/main/java/com/google/android/accessibility/brailleime/BrailleIme.java
@@ -581,13 +581,8 @@ public class BrailleIme extends InputMethodService {
       // This api doesn't tell us switch succeed or not. Assume it switch successfully.
       switchInputMethod(inputMethodInfoId);
       succeeded = true;
-    } else if (BuildVersionUtils.isAtLeastP()) {
-      succeeded = switchToNextInputMethod(false);
     } else {
-      IBinder token = getWindow().getWindow().getAttributes().token;
-      InputMethodManager inputMethodManager =
-          (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-      succeeded = inputMethodManager.switchToNextInputMethod(token, false);
+      succeeded = switchToNextInputMethod(false);
     }
     // REFERTO: Switch to next keyboard manually by giving ime id.
     if (!succeeded) {

--- a/brailleime/src/main/java/com/google/android/accessibility/brailleime/translate/liblouis/LibLouisTranslator.java
+++ b/brailleime/src/main/java/com/google/android/accessibility/brailleime/translate/liblouis/LibLouisTranslator.java
@@ -46,7 +46,7 @@ class LibLouisTranslator implements Translator {
     File tablesDir;
     // Extract tables to device storage so we can read tables before device is unlocked after
     // reboot.
-      context = ContextCompat.createDeviceProtectedStorageContext(context);
+    context = ContextCompat.createDeviceProtectedStorageContext(context);
     File customTablesDir = context.getExternalFilesDir(/* type= */ null);
     File customTablesSubDir = new File(customTablesDir, "/liblouis/tables");
     File[] files = customTablesSubDir.listFiles();

--- a/brailleime/src/main/java/com/google/android/accessibility/brailleime/translate/liblouis/LibLouisTranslator.java
+++ b/brailleime/src/main/java/com/google/android/accessibility/brailleime/translate/liblouis/LibLouisTranslator.java
@@ -46,9 +46,7 @@ class LibLouisTranslator implements Translator {
     File tablesDir;
     // Extract tables to device storage so we can read tables before device is unlocked after
     // reboot.
-    if (BuildVersionUtils.isAtLeastN()) {
       context = ContextCompat.createDeviceProtectedStorageContext(context);
-    }
     File customTablesDir = context.getExternalFilesDir(/* type= */ null);
     File customTablesSubDir = new File(customTablesDir, "/liblouis/tables");
     File[] files = customTablesSubDir.listFiles();

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ android {
         versionName "370044210"
         versionCode 370044210
         manifestPlaceholders = [talkbackMainPermission:talkbackMainPermission]
-        minSdkVersion 26
+        minSdkVersion 28
         targetSdkVersion 31
         testInstrumentationRunner 'android.test.InstrumentationTestRunner'
         multiDexEnabled true

--- a/shared.gradle
+++ b/shared.gradle
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true
-        minSdkVersion 26
+        minSdkVersion 28
     }
     lintOptions {
         abortOnError false

--- a/talkback/src/main/java/com/google/android/accessibility/talkback/BootReceiver.java
+++ b/talkback/src/main/java/com/google/android/accessibility/talkback/BootReceiver.java
@@ -43,11 +43,6 @@ public class BootReceiver extends BroadcastReceiver {
         service.onLockedBootCompleted(eventId);
         break;
       case Intent.ACTION_BOOT_COMPLETED:
-        if (!BuildVersionUtils.isAtLeastN()) {
-          // Pre-N devices will never get LOCKED_BOOT, so we need to do the locked-boot
-          // initialization here right before we do the unlocked-boot initialization.
-          service.onLockedBootCompleted(eventId);
-        }
         service.onUnlockedBootCompleted();
         break;
       default: // fall out

--- a/talkback/src/main/java/com/google/android/accessibility/talkback/MediaRecorderMonitor.java
+++ b/talkback/src/main/java/com/google/android/accessibility/talkback/MediaRecorderMonitor.java
@@ -64,24 +64,20 @@ public class MediaRecorderMonitor {
 
   public MediaRecorderMonitor(Context context) {
     audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-    if (BuildVersionUtils.isAtLeastN()) {
-      audioRecordingCallback =
-          new AudioRecordingCallback() {
-            @Override
-            public void onRecordingConfigChanged(List<AudioRecordingConfiguration> configs) {
-              super.onRecordingConfigChanged(configs);
-              isVoiceRecognitionActive =
-                  containsAudioSource(configs, AudioSource.VOICE_RECOGNITION);
-              final boolean isRecording = containsAudioSources(configs);
-              if (!MediaRecorderMonitor.this.isRecording && isRecording) {
-                listener.onMicrophoneActivated();
-              }
-              MediaRecorderMonitor.this.isRecording = isRecording;
+    audioRecordingCallback =
+        new AudioRecordingCallback() {
+          @Override
+          public void onRecordingConfigChanged(List<AudioRecordingConfiguration> configs) {
+            super.onRecordingConfigChanged(configs);
+            isVoiceRecognitionActive =
+                containsAudioSource(configs, AudioSource.VOICE_RECOGNITION);
+            final boolean isRecording = containsAudioSources(configs);
+            if (!MediaRecorderMonitor.this.isRecording && isRecording) {
+              listener.onMicrophoneActivated();
             }
-          };
-    } else {
-      audioRecordingCallback = null;
-    }
+            MediaRecorderMonitor.this.isRecording = isRecording;
+          }
+        };
   }
 
   public boolean isMicrophoneActive() {

--- a/talkback/src/main/java/com/google/android/accessibility/talkback/ScrollEventInterpreter.java
+++ b/talkback/src/main/java/com/google/android/accessibility/talkback/ScrollEventInterpreter.java
@@ -169,7 +169,7 @@ public class ScrollEventInterpreter implements AccessibilityEventListener {
    * Timeout to determine whether a scroll event could be resulted from the last scroll action.
    * REFERTO Extends the timeout for M devices due to late TYPE_VIEW_SCROLLED event.
    */
-  public static final int SCROLL_TIMEOUT_MS = BuildVersionUtils.isAtLeastN() ? 500 : 1000;
+  public static final int SCROLL_TIMEOUT_MS = 500;
 
   /** Undefined scroll position index. */
   private static final int INDEX_UNDEFINED = -1;

--- a/talkback/src/main/java/com/google/android/accessibility/talkback/TalkBackService.java
+++ b/talkback/src/main/java/com/google/android/accessibility/talkback/TalkBackService.java
@@ -1596,9 +1596,7 @@ public class TalkBackService extends AccessibilityService
     info.flags |= AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS;
     info.flags |= AccessibilityServiceInfo.FLAG_REQUEST_FILTER_KEY_EVENTS;
     info.flags |= AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS;
-    if (BuildVersionUtils.isAtLeastO()) {
-      info.flags |= AccessibilityServiceInfo.FLAG_ENABLE_ACCESSIBILITY_VOLUME;
-    }
+    info.flags |= AccessibilityServiceInfo.FLAG_ENABLE_ACCESSIBILITY_VOLUME;
     info.flags |= ExperimentalUtils.getAddtionalTalkBackServiceFlags();
     if (FeatureSupport.isMultiFingerGestureSupported()) {
       info.flags |=
@@ -1677,11 +1675,9 @@ public class TalkBackService extends AccessibilityService
       registerReceiver(televisionDPadManager, TelevisionDPadManager.getFilter());
     }
 
-    if (BuildVersionUtils.isAtLeastN()) {
-      MagnificationController magnificationController = getMagnificationController();
-      if (magnificationController != null && onMagnificationChangedListener != null) {
-        magnificationController.addListener(onMagnificationChangedListener);
-      }
+    MagnificationController magnificationController = getMagnificationController();
+    if (magnificationController != null && onMagnificationChangedListener != null) {
+      magnificationController.addListener(onMagnificationChangedListener);
     }
 
     if ((fingerprintGestureCallback != null) && (getFingerprintGestureController() != null)) {
@@ -1774,11 +1770,9 @@ public class TalkBackService extends AccessibilityService
     final NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
     nm.cancelAll();
 
-    if (BuildVersionUtils.isAtLeastN()) {
-      MagnificationController magnificationController = getMagnificationController();
-      if (magnificationController != null && onMagnificationChangedListener != null) {
-        magnificationController.removeListener(onMagnificationChangedListener);
-      }
+    MagnificationController magnificationController = getMagnificationController();
+    if (magnificationController != null && onMagnificationChangedListener != null) {
+      magnificationController.removeListener(onMagnificationChangedListener);
     }
 
     if ((fingerprintGestureCallback != null) && (getFingerprintGestureController() != null)) {

--- a/talkback/src/main/java/com/google/android/accessibility/talkback/controller/TelevisionNavigationController.java
+++ b/talkback/src/main/java/com/google/android/accessibility/talkback/controller/TelevisionNavigationController.java
@@ -380,10 +380,6 @@ public class TelevisionNavigationController implements ServiceKeyEventListener {
         if (!shouldProcessDPadKeyEvent) {
           return false;
         }
-        if (!BuildVersionUtils.isAtLeastN()) {
-          // For before N platforms, only handle when we are not ignoring UP/DOWN key
-          return !AccessibilityNodeInfoUtils.isOrHasMatchingAncestor(cursor, IGNORE_UP_DOWN_M);
-        }
         return true;
       case KeyEvent.KEYCODE_DPAD_LEFT:
       case KeyEvent.KEYCODE_DPAD_RIGHT:

--- a/talkback/src/main/java/com/google/android/accessibility/talkback/eventprocessor/AccessibilityEventProcessor.java
+++ b/talkback/src/main/java/com/google/android/accessibility/talkback/eventprocessor/AccessibilityEventProcessor.java
@@ -58,12 +58,6 @@ public class AccessibilityEventProcessor {
   private static final String DUMP_EVENT_LOG_FORMAT = "A11yEventDumper: %s";
   private TalkBackListener testingListener;
 
-  /**
-   * Used to not drop TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED for the below android versions to fix
-   * permissions dialog overlay
-   */
-  private static final boolean API_REQUIRES_PERMISSION_OVERLAY = !BuildVersionUtils.isAtLeastNMR1();
-
   /** Event types to drop after receiving a window state change. */
   public static final int AUTOMATIC_AFTER_STATE_CHANGE =
       AccessibilityEvent.TYPE_VIEW_FOCUSED
@@ -279,14 +273,6 @@ public class AccessibilityEventProcessor {
             lastClearedSourceId = -1;
             lastClearedWindowId = -1;
             lastClearA11yFocus = 0;
-          }
-          // The event needs to be sent to ProcessorPermissionDialogs
-          // to clear the overlay
-          if (source != null
-              && API_REQUIRES_PERMISSION_OVERLAY
-              && TextUtils.equals(
-                  ProcessorPermissionDialogs.ALLOW_BUTTON, source.getViewIdResourceName())) {
-            return false;
           }
         } catch (Exception e) {
           LogUtils.d(TAG, "Exception accessing field: " + e.toString());

--- a/talkback/src/main/java/com/google/android/accessibility/talkback/eventprocessor/ProcessorPermissionDialogs.java
+++ b/talkback/src/main/java/com/google/android/accessibility/talkback/eventprocessor/ProcessorPermissionDialogs.java
@@ -39,15 +39,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * dialog will not work when an overlay (such as the screen dimming overlay) is present.
  */
 public class ProcessorPermissionDialogs implements AccessibilityEventListener, OnDoubleTapListener {
-
-  /**
-   * The permissions dialogs start to appear from M to N. For N_MR1, the overlay does not restrict
-   * the touch action on dim screen and starting from O, we don't need this workaround because
-   * framework performs ACTION_CLICK instead of mocking touch down/up actions when double tap on
-   * screen. Thus the target API level is M <= api level <= N.
-   */
-  private static final boolean IS_API_LEVEL_SUPPORTED = !BuildVersionUtils.isAtLeastNMR1();
-
   public static final String ALLOW_BUTTON =
       "com.android.packageinstaller:id/permission_allow_button";
 
@@ -73,14 +64,10 @@ public class ProcessorPermissionDialogs implements AccessibilityEventListener, O
   }
 
   public void onReloadPreferences(TalkBackService service) {
-    boolean supported = IS_API_LEVEL_SUPPORTED && NodeBlockingOverlay.isSupported(service);
-    if (registered && !supported) {
+    if (registered) {
       service.postRemoveEventListener(this);
       clearNode();
       registered = false;
-    } else if (!registered && supported) {
-      service.addEventListener(this);
-      registered = true;
     }
   }
 

--- a/talkback/src/main/res/xml-v31/accessibilityservice.xml
+++ b/talkback/src/main/res/xml-v31/accessibilityservice.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeAllMask"
+    android:accessibilityFeedbackType="feedbackSpoken|feedbackHaptic|feedbackAudible"
+    android:accessibilityFlags="flagDefault|flagRequestTouchExplorationMode|flagReportViewIds|flagRequestFilterKeyEvents|flagEnableAccessibilityVolume|flagRetrieveInteractiveWindows|flagRequestShortcutWarningDialogSpokenFeedback"
+    android:canRequestFilterKeyEvents="true"
+    android:canRequestTouchExplorationMode="true"
+    android:canControlMagnification="true"
+    android:canRetrieveWindowContent="true"
+    android:canRequestFingerprintGestures="true"
+    android:summary="@string/talkback_service_summary"
+    android:notificationTimeout="0"
+    android:interactiveUiTimeout="10000"
+    android:animatedImageDrawable="@drawable/talkback_intro"
+    android:htmlDescription="@string/talkback_service_html_description"
+    android:settingsActivity="com.android.talkback.TalkBackPreferencesActivity"
+    android:isAccessibilityTool="true" />

--- a/utils/src/main/java/com/google/android/accessibility/utils/AccessibilityEventUtils.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/AccessibilityEventUtils.java
@@ -196,15 +196,7 @@ public class AccessibilityEventUtils {
     // TODO: Find better way to handle volume slider.
     CharSequence packageName = event.getPackageName();
     CharSequence sourceClassName = event.getClassName();
-    boolean isVolumeInAndroidP =
-        BuildVersionUtils.isAtLeastP()
-            && TextUtils.equals(sourceClassName, VOLUME_CONTROLS_CLASS_IN_ANDROID_P);
-    boolean isVolumeInAndroidO =
-        BuildVersionUtils.isAtLeastO()
-            && (!BuildVersionUtils.isAtLeastP())
-            && TextUtils.equals(sourceClassName, VOLUME_DIALOG_CLASS_NAME);
-    return TextUtils.equals(SYSTEM_UI_PACKAGE_NAME, packageName)
-        && (isVolumeInAndroidO || isVolumeInAndroidP);
+    return TextUtils.equals(SYSTEM_UI_PACKAGE_NAME, packageName);
   }
 
   /** Returns whether the {@link AccessibilityEvent} contains {@link Notification} data. */
@@ -581,16 +573,15 @@ public class AccessibilityEventUtils {
   // Methods to get scroll data
 
   public static int getScrollDeltaX(AccessibilityEvent event) {
-    return BuildVersionUtils.isAtLeastP() ? event.getScrollDeltaX() : DELTA_UNDEFINED;
+    return event.getScrollDeltaX();
   }
 
   public static int getScrollDeltaY(AccessibilityEvent event) {
-    return BuildVersionUtils.isAtLeastP() ? event.getScrollDeltaY() : DELTA_UNDEFINED;
+    return event.getScrollDeltaY();
   }
 
   public static boolean hasValidScrollDelta(AccessibilityEvent event) {
-    return BuildVersionUtils.isAtLeastP()
-        && ((event.getScrollDeltaX() != DELTA_UNDEFINED)
+    return ((event.getScrollDeltaX() != DELTA_UNDEFINED)
             || (event.getScrollDeltaY() != DELTA_UNDEFINED));
   }
 }

--- a/utils/src/main/java/com/google/android/accessibility/utils/AccessibilityNodeInfoUtils.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/AccessibilityNodeInfoUtils.java
@@ -1637,22 +1637,14 @@ public class AccessibilityNodeInfoUtils {
     // translation from the DOM to the AccessibilityNodeInfo.) To avoid labeling views that don't
     // support scrolling (e.g. REFERTO), check for the explicit presence of
     // AccessibilityActions.
-    if (BuildVersionUtils.isM() || BuildVersionUtils.isAtLeastN()) {
-      return supportsAnyAction(
-          node,
-          AccessibilityAction.ACTION_SCROLL_FORWARD,
-          AccessibilityAction.ACTION_SCROLL_BACKWARD,
-          AccessibilityAction.ACTION_SCROLL_DOWN,
-          AccessibilityAction.ACTION_SCROLL_UP,
-          AccessibilityAction.ACTION_SCROLL_RIGHT,
-          AccessibilityAction.ACTION_SCROLL_LEFT);
-    } else {
-      // Directional scrolling is not available pre-M.
-      return supportsAnyAction(
-          node,
-          AccessibilityAction.ACTION_SCROLL_FORWARD,
-          AccessibilityAction.ACTION_SCROLL_BACKWARD);
-    }
+    return supportsAnyAction(
+        node,
+        AccessibilityAction.ACTION_SCROLL_FORWARD,
+        AccessibilityAction.ACTION_SCROLL_BACKWARD,
+        AccessibilityAction.ACTION_SCROLL_DOWN,
+        AccessibilityAction.ACTION_SCROLL_UP,
+        AccessibilityAction.ACTION_SCROLL_RIGHT,
+        AccessibilityAction.ACTION_SCROLL_LEFT);
   }
 
   /**
@@ -1720,12 +1712,6 @@ public class AccessibilityNodeInfoUtils {
       parent = node.getParent();
       if (parent == null) {
         // Not a child node of anything.
-        return false;
-      }
-
-      // Certain scrollable views in M's Android TV SetupWraith are permanently broken and
-      // won't ever be fixed because the setup wizard is bundled. This affects <= M only.
-      if (!BuildVersionUtils.isAtLeastN() && FILTER_BROKEN_LISTS_TV_M.accept(parent)) {
         return false;
       }
 
@@ -2172,7 +2158,7 @@ public class AccessibilityNodeInfoUtils {
   @Nullable
   public static List<Rect> getTextLocations(
       AccessibilityNodeInfoCompat node, CharSequence text, int fromCharIndex, int toCharIndex) {
-    if (node == null || !BuildVersionUtils.isAtLeastO()) {
+    if (node == null) {
       return null;
     }
 
@@ -2217,7 +2203,7 @@ public class AccessibilityNodeInfoUtils {
   /** Returns true if the node supports text location data. */
   @TargetApi(Build.VERSION_CODES.O)
   public static boolean supportsTextLocation(AccessibilityNodeInfoCompat node) {
-    if (!BuildVersionUtils.isAtLeastO() || node == null) {
+    if (node == null) {
       return false;
     }
     AccessibilityNodeInfo info = node.unwrap();
@@ -2264,10 +2250,6 @@ public class AccessibilityNodeInfoUtils {
    * must recycle the node that is returned from this method.
    */
   public static AccessibilityNodeInfoCompat getAnchor(@Nullable AccessibilityNodeInfoCompat node) {
-    if (!BuildVersionUtils.isAtLeastN()) {
-      return null;
-    }
-
     if (node == null) {
       return null;
     }

--- a/utils/src/main/java/com/google/android/accessibility/utils/AccessibilityServiceCompatUtils.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/AccessibilityServiceCompatUtils.java
@@ -58,21 +58,11 @@ public class AccessibilityServiceCompatUtils {
   }
 
   public static List<AccessibilityWindowInfo> getWindows(AccessibilityService service) {
-    if (BuildVersionUtils.isAtLeastN()) {
-      // Use try/catch to fix REFERTO
-      try {
-        return service.getWindows();
-      } catch (SecurityException e) {
-        LogUtils.e(TAG, "SecurityException occurred at AccessibilityService#getWindows(): %s", e);
-        return Collections.emptyList();
-      }
-    }
-    // If build version is not isAtLeastN(), there is a chance of ClassCastException or
-    // NullPointerException.
+    // Use try/catch to fix REFERTO
     try {
       return service.getWindows();
-    } catch (Exception e) {
-      LogUtils.e(TAG, "Exception occurred at AccessibilityService#getWindows(): %s", e);
+    } catch (SecurityException e) {
+      LogUtils.e(TAG, "SecurityException occurred at AccessibilityService#getWindows(): %s", e);
       return Collections.emptyList();
     }
   }

--- a/utils/src/main/java/com/google/android/accessibility/utils/AccessibilityWindow.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/AccessibilityWindow.java
@@ -270,11 +270,7 @@ public class AccessibilityWindow {
     if (bare == null) {
       return null;
     }
-    if (BuildVersionUtils.isAtLeastO()) {
-      return bare.isInPictureInPictureMode();
-    } else {
-      return false;
-    }
+    return bare.isInPictureInPictureMode();
   }
 
   /** Returns the window id if available, otherwise returns {@code WINDOW_ID_UNKNOWN}. */

--- a/utils/src/main/java/com/google/android/accessibility/utils/AccessibilityWindowInfoUtils.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/AccessibilityWindowInfoUtils.java
@@ -63,26 +63,11 @@ public class AccessibilityWindowInfoUtils {
 
   /** Returns window bounds. */
   public static @Nullable Rect getBounds(AccessibilityWindowInfo window) {
-    if (BuildVersionUtils.isAtLeastO()) {
-      // Rely on window bounds in newer android. Root view may be larger than window, particularly
-      // for the split-screen window with launcher in window-2 position.
-      Rect bounds = new Rect();
-      window.getBoundsInScreen(bounds);
-      return bounds;
-    } else {
-      // Get bounds from root view, because some window bounds may be inaccurate on older android.
-      AccessibilityNodeInfo root = getRoot(window);
-      try {
-        if (root == null) {
-          return null;
-        }
-        Rect bounds = new Rect();
-        root.getBoundsInScreen(bounds);
-        return bounds;
-      } finally {
-        AccessibilityNodeInfoUtils.recycleNodes(root);
-      }
-    }
+    // Rely on window bounds. Root view may be larger than window, particularly
+    // for the split-screen window with launcher in window-2 position.
+    Rect bounds = new Rect();
+    window.getBoundsInScreen(bounds);
+    return bounds;
   }
 
   /**
@@ -106,7 +91,7 @@ public class AccessibilityWindowInfoUtils {
 
   @TargetApi(VERSION_CODES.O)
   public static boolean isPictureInPicture(@Nullable AccessibilityWindowInfo window) {
-    return BuildVersionUtils.isAtLeastO() && (window != null) && window.isInPictureInPictureMode();
+    return (window != null) && window.isInPictureInPictureMode();
   }
 
   public static boolean equals(AccessibilityWindowInfo window1, AccessibilityWindowInfo window2) {

--- a/utils/src/main/java/com/google/android/accessibility/utils/AudioPlaybackMonitor.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/AudioPlaybackMonitor.java
@@ -71,22 +71,18 @@ public class AudioPlaybackMonitor {
   @TargetApi(Build.VERSION_CODES.O)
   public AudioPlaybackMonitor(Context context) {
     audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-    if (BuildVersionUtils.isAtLeastO()) {
-      audioPlaybackCallback =
-          new AudioManager.AudioPlaybackCallback() {
-            @Override
-            public void onPlaybackConfigChanged(List<AudioPlaybackConfiguration> configs) {
-              super.onPlaybackConfigChanged(configs);
-              final boolean isPlaying = containsAudioPlaybackSources(configs);
-              if (listener != null && !AudioPlaybackMonitor.this.isPlaying && isPlaying) {
-                listener.onAudioPlaybackActivated();
-              }
-              AudioPlaybackMonitor.this.isPlaying = isPlaying;
+    audioPlaybackCallback =
+        new AudioManager.AudioPlaybackCallback() {
+          @Override
+          public void onPlaybackConfigChanged(List<AudioPlaybackConfiguration> configs) {
+            super.onPlaybackConfigChanged(configs);
+            final boolean isPlaying = containsAudioPlaybackSources(configs);
+            if (listener != null && !AudioPlaybackMonitor.this.isPlaying && isPlaying) {
+              listener.onAudioPlaybackActivated();
             }
-          };
-    } else {
-      audioPlaybackCallback = null;
-    }
+            AudioPlaybackMonitor.this.isPlaying = isPlaying;
+          }
+        };
   }
 
   public boolean isAudioPlaybackActive() {
@@ -98,9 +94,6 @@ public class AudioPlaybackMonitor {
   }
 
   public boolean isPlaybackSourceActive(PlaybackSource source) {
-    if (!BuildVersionUtils.isAtLeastO() || source == null) {
-      return false;
-    }
     List<AudioPlaybackConfiguration> configs = audioManager.getActivePlaybackConfigurations();
     for (AudioPlaybackConfiguration config : configs) {
       if (config.getAudioAttributes().getUsage() == source.getId()) {
@@ -131,9 +124,6 @@ public class AudioPlaybackMonitor {
 
   /** Returns status summary for logging only. */
   public String getStatusSummary() {
-    if (!BuildVersionUtils.isAtLeastO()) {
-      return "";
-    }
     String result = "";
     result += "[";
     for (PlaybackSource source : PlaybackSource.values()) {

--- a/utils/src/main/java/com/google/android/accessibility/utils/AudioPlaybackMonitor.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/AudioPlaybackMonitor.java
@@ -94,6 +94,9 @@ public class AudioPlaybackMonitor {
   }
 
   public boolean isPlaybackSourceActive(PlaybackSource source) {
+	   if (source == null) {
+		    return false;
+		  }
     List<AudioPlaybackConfiguration> configs = audioManager.getActivePlaybackConfigurations();
     for (AudioPlaybackConfiguration config : configs) {
       if (config.getAudioAttributes().getUsage() == source.getId()) {

--- a/utils/src/main/java/com/google/android/accessibility/utils/CollectionState.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/CollectionState.java
@@ -923,34 +923,16 @@ public class CollectionState {
     return true;
   }
 
-  /**
-   * Don't compute headers if: (1) API level is pre-N, and (2) the collection root is not a
-   * descendant of a WebView, and (3) the collection root is itself a ListView or GridView.
-   *
-   * <p>Under these circumstances, the framework ListView/GridView will mark headers as non-headers
-   * and vice-versa.
-   */
   private static boolean shouldComputeHeaders(@NonNull AccessibilityNodeInfoCompat collectionRoot) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-      if (!AccessibilityNodeInfoUtils.hasMatchingAncestor(collectionRoot, FILTER_WEBVIEW)) {
-        // TODO: Convert to use Role.
-        // Bugs exist in specific classes, so check class names and not roles.
-        if (AccessibilityNodeInfoUtils.nodeIsListOrGrid(collectionRoot)) {
-          return false;
-        }
-      }
-    }
-
     return true;
   }
 
   /**
-   * Don't compute indices or row/column counts if: (1) API level is pre-N, (2) the collection root
-   * is not a descendant of a WebView, and (3) the collection root is not a pager.
+   * Don't compute indices or row/column counts if: (1) the collection root
+   * is not a descendant of a WebView, and (2) the collection root is not a pager.
    *
    * <p>Item indices are broken in some major first-party apps that use "spacer" items in
-   * collections; this check makes sure no apps in the wild are affected. TODO: Re-evaluate
-   * this check before N release to see if it needs to be extended to N.
+   * collections; this check makes sure no apps in the wild are affected.
    *
    * <p>Always compute for pagers. The ability to have pagers with collections was introduced after
    * these bugs, and visually pagers should not have "spacer" items.
@@ -960,12 +942,6 @@ public class CollectionState {
     if (Role.getRole(collectionRoot) == Role.ROLE_PAGER) {
       return true;
     }
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-      if (!AccessibilityNodeInfoUtils.hasMatchingAncestor(collectionRoot, FILTER_WEBVIEW)) {
-        return false;
-      }
-    }
-
     return true;
   }
 }

--- a/utils/src/main/java/com/google/android/accessibility/utils/DisplayUtils.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/DisplayUtils.java
@@ -69,14 +69,7 @@ public final class DisplayUtils {
     Configuration configuration = new Configuration(res.getConfiguration());
 
     /* get default display density */
-    if (BuildVersionUtils.isAtLeastN()) {
-      configuration.densityDpi = DisplayMetrics.DENSITY_DEVICE_STABLE;
-    } else {
-      WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-      DisplayMetrics dm = new DisplayMetrics();
-      wm.getDefaultDisplay().getRealMetrics(dm);
-      configuration.densityDpi = dm.densityDpi;
-    }
+    configuration.densityDpi = DisplayMetrics.DENSITY_DEVICE_STABLE;
     configuration.setTo(configuration);
 
     return context.createConfigurationContext(configuration);

--- a/utils/src/main/java/com/google/android/accessibility/utils/FeatureSupport.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/FeatureSupport.java
@@ -66,16 +66,16 @@ public final class FeatureSupport {
 
   /** Returns {@code true} if the device supports accessibility shortcut. */
   public static boolean hasAccessibilityShortcut(Context context) {
-    return isPhoneOrTablet(context) && BuildVersionUtils.isAtLeastO();
+    return isPhoneOrTablet(context);
   }
 
   public static boolean useSpeakPasswordsServicePref() {
-    return BuildVersionUtils.isAtLeastO();
+    return true;
   }
 
   /** Returns {@code true} for devices which have separate audio a11y stream. */
   public static boolean hasAccessibilityAudioStream(Context context) {
-    return BuildVersionUtils.isAtLeastO() && !isTv(context);
+    return !isTv(context);
   }
 
   /** Return whether fingerprint feature & fingerprint gesture is supported on this device. */
@@ -85,8 +85,7 @@ public final class FeatureSupport {
       return false;
     }
 
-    return BuildVersionUtils.isAtLeastO()
-        && context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_FINGERPRINT)
+    return context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_FINGERPRINT)
         && !isWatch(context);
   }
 
@@ -99,11 +98,11 @@ public final class FeatureSupport {
   }
 
   public static boolean supportsVolumeKeyShortcuts() {
-    return !BuildVersionUtils.isAtLeastO();
+    return false;
   }
 
   public static boolean disableAnimation() {
-    return BuildVersionUtils.isAtLeastP();
+    return true;
   }
 
   public static boolean supportReadClipboard() {
@@ -122,16 +121,16 @@ public final class FeatureSupport {
   }
 
   public static boolean supportNotificationChannel() {
-    return BuildVersionUtils.isAtLeastO();
+    return true;
   }
 
   public static boolean isHeadingWorks() {
-    return BuildVersionUtils.isAtLeastN();
+    return true;
   }
 
   /** Returns {@code true} if the device supports {@link AccessibilityWindowInfo#getTitle()}. */
   public static boolean supportGetTitleFromWindows() {
-    return BuildVersionUtils.isAtLeastN();
+    return true;
   }
 
   public static boolean supportSwitchToInputMethod() {
@@ -152,11 +151,11 @@ public final class FeatureSupport {
   }
 
   public static boolean supportMagnificationController() {
-    return BuildVersionUtils.isAtLeastN();
+    return true;
   }
 
   public static boolean isBoundsScaledUpByMagnifier() {
-    return BuildVersionUtils.isAtLeastOMR1();
+    return true;
   }
 
   public static boolean supportMultiDisplay() {
@@ -174,7 +173,7 @@ public final class FeatureSupport {
    * @return {@code true} if the device supports change slider
    */
   public static boolean supportChangeSlider() {
-    return BuildVersionUtils.isAtLeastN();
+    return true;
   }
 
   /**
@@ -202,7 +201,7 @@ public final class FeatureSupport {
 
   /** Returns {@code true} if the device supports customizing bullet radius. */
   public static boolean customBulletRadius() {
-    return BuildVersionUtils.isAtLeastP();
+    return true;
   }
 
   /** Returns {@code true} if the device supports sending motion events of gestures. */
@@ -213,7 +212,7 @@ public final class FeatureSupport {
 
   /** Returns {@code true} if the device supports long version code. */
   public static boolean supportLongVersionCode() {
-    return BuildVersionUtils.isAtLeastP();
+    return true;
   }
 
   /**
@@ -225,7 +224,7 @@ public final class FeatureSupport {
    * @return {@code true} if the device supports accessibility button
    */
   public static boolean supportAccessibilityButton() {
-    return BuildVersionUtils.isAtLeastO();
+    return true;
   }
 
   /** Returns {@code true} if the device supports accessibility multi-display. */

--- a/utils/src/main/java/com/google/android/accessibility/utils/PreferenceSettingsUtils.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/PreferenceSettingsUtils.java
@@ -100,9 +100,7 @@ public final class PreferenceSettingsUtils {
   public static void setPreferencesFromResource(
       PreferenceFragmentCompat preferenceFragment, @XmlRes int preferencesResId, String key) {
     // Set preferences to use device-protected storage.
-    if (BuildVersionUtils.isAtLeastN()) {
-      preferenceFragment.getPreferenceManager().setStorageDeviceProtected();
-    }
+    preferenceFragment.getPreferenceManager().setStorageDeviceProtected();
     preferenceFragment.setPreferencesFromResource(preferencesResId, key);
   }
 
@@ -113,9 +111,7 @@ public final class PreferenceSettingsUtils {
   public static void addPreferencesFromResource(
       PreferenceFragmentCompat preferenceFragment, @XmlRes int preferencesResId) {
     // Set preferences to use device-protected storage.
-    if (BuildVersionUtils.isAtLeastN()) {
-      preferenceFragment.getPreferenceManager().setStorageDeviceProtected();
-    }
+    preferenceFragment.getPreferenceManager().setStorageDeviceProtected();
     preferenceFragment.addPreferencesFromResource(preferencesResId);
   }
 
@@ -126,9 +122,7 @@ public final class PreferenceSettingsUtils {
   public static void addPreferencesFromResource(
       PreferenceFragment preferenceFragment, @XmlRes int preferencesResId) {
     // Set preferences to use device-protected storage.
-    if (BuildVersionUtils.isAtLeastN()) {
-      preferenceFragment.getPreferenceManager().setStorageDeviceProtected();
-    }
+    preferenceFragment.getPreferenceManager().setStorageDeviceProtected();
     preferenceFragment.addPreferencesFromResource(preferencesResId);
   }
 

--- a/utils/src/main/java/com/google/android/accessibility/utils/SharedKeyEvent.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/SharedKeyEvent.java
@@ -67,14 +67,6 @@ public class SharedKeyEvent {
    * @param keyEvent Event received from the system.
    */
   public static boolean onKeyEvent(Listener listener, KeyEvent keyEvent) {
-    if (BuildVersionUtils.isAtLeastN()) {
-      return listener.onKeyEventShared(keyEvent);
-    } else {
-      boolean handled = false;
-      for (Listener currentListener : sListeners) {
-        handled = currentListener.onKeyEventShared(keyEvent) || handled;
-      }
-      return handled;
-    }
+    return listener.onKeyEventShared(keyEvent);
   }
 }

--- a/utils/src/main/java/com/google/android/accessibility/utils/SharedPreferencesUtils.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/SharedPreferencesUtils.java
@@ -208,11 +208,9 @@ public class SharedPreferencesUtils {
    * Build.VERSION < N to Build.VERSION >= N.
    */
   public static void migrateSharedPreferences(Context context) {
-    if (BuildVersionUtils.isAtLeastN()) {
-      Context deContext = ContextCompat.createDeviceProtectedStorageContext(context);
-      deContext.moveSharedPreferencesFrom(
-          context, PreferenceManager.getDefaultSharedPreferencesName(context));
-    }
+    Context deContext = ContextCompat.createDeviceProtectedStorageContext(context);
+    deContext.moveSharedPreferencesFrom(
+        context, PreferenceManager.getDefaultSharedPreferencesName(context));
   }
 
   /** Removes the preferences. */

--- a/utils/src/main/java/com/google/android/accessibility/utils/SpannableUtils.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/SpannableUtils.java
@@ -173,26 +173,17 @@ public final class SpannableUtils {
       // Extra data.
       if (span instanceof LocaleSpan) {
         LocaleSpan localeSpan = (LocaleSpan) span;
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-          Locale locale = localeSpan.getLocale();
-          if (locale != null) {
-            stringBuilder.append(" locale=");
-            stringBuilder.append(locale);
+        LocaleList localeList = localeSpan.getLocales();
+        int size = localeList.size();
+        if (size > 0) {
+          stringBuilder.append(" locale=[");
+          for (int i = 0; i < size - 1; i++) {
+            stringBuilder.append(localeList.get(i));
+            stringBuilder.append(",");
           }
-        } else {
-          LocaleList localeList = localeSpan.getLocales();
-          int size = localeList.size();
-          if (size > 0) {
-            stringBuilder.append(" locale=[");
-            for (int i = 0; i < size - 1; i++) {
-              stringBuilder.append(localeList.get(i));
-              stringBuilder.append(",");
-            }
-            stringBuilder.append(localeList.get(size - 1));
-            stringBuilder.append("]");
-          }
+          stringBuilder.append(localeList.get(size - 1));
+          stringBuilder.append("]");
         }
-
       } else if (span instanceof TtsSpan) {
         TtsSpan ttsSpan = (TtsSpan) span;
         stringBuilder.append(" ttsType=");

--- a/utils/src/main/java/com/google/android/accessibility/utils/WindowEventInterpreter.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/WindowEventInterpreter.java
@@ -245,7 +245,7 @@ public class WindowEventInterpreter {
     this.service = service;
     boolean isArc = FeatureSupport.isArc();
     isSplitScreenModeAvailable =
-        BuildVersionUtils.isAtLeastN() && !FeatureSupport.isTv(service) && !isArc;
+        !FeatureSupport.isTv(service) && !isArc;
   }
 
   public void setReduceDelayPref(boolean reduceDelayPref) {
@@ -319,8 +319,7 @@ public class WindowEventInterpreter {
     if (event == null || event.getEventType() != AccessibilityEvent.TYPE_WINDOWS_CHANGED) {
       return false;
     }
-    if (BuildVersionUtils.isAtLeastP()
-        && ((event.getWindowChanges() & WINDOWS_CHANGE_TYPES_USED) == 0)) {
+    if (((event.getWindowChanges() & WINDOWS_CHANGE_TYPES_USED) == 0)) {
       return false;
     }
     return true;
@@ -431,14 +430,10 @@ public class WindowEventInterpreter {
     interpretation.setOriginalEvent(true);
     interpretation.setWindowIdFromEvent(AccessibilityEventUtils.getWindowId(event));
     if (event.getEventType() == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) {
-      if (BuildVersionUtils.isAtLeastP()) {
-        interpretation.setChangeTypes(event.getContentChangeTypes());
-      }
+      interpretation.setChangeTypes(event.getContentChangeTypes());
     } else if (event.getEventType() == AccessibilityEvent.TYPE_WINDOWS_CHANGED) {
       areWindowsChanging = true;
-      if (BuildVersionUtils.isAtLeastP()) {
-        interpretation.setChangeTypes(event.getWindowChanges());
-      }
+      interpretation.setChangeTypes(event.getWindowChanges());
     }
 
     // Collect old window information into interpretation.
@@ -868,16 +863,11 @@ public class WindowEventInterpreter {
           }
           break;
         case AccessibilityWindowInfo.TYPE_ACCESSIBILITY_OVERLAY:
-          // From LMR1 to N, for Talkback we create a transparent a11y overlay on edit text when
-          // double click is performed. That is done so that we can adjust the cursor position to
-          // the end of the edit text instead of the center, which is the default behavior. This
-          // overlay should be ignored while detecting window changes.
-          boolean isOverlayOnEditTextSupported = !BuildVersionUtils.isAtLeastO();
           AccessibilityNodeInfo root = AccessibilityWindowInfoUtils.getRoot(window);
           boolean isTalkbackOverlay = (Role.getRole(root) == Role.ROLE_TALKBACK_EDIT_TEXT_OVERLAY);
           AccessibilityNodeInfoUtils.recycleNodes(root);
           // Only add overlay window not shown by talkback.
-          if (!isOverlayOnEditTextSupported || !isTalkbackOverlay) {
+          if (!isTalkbackOverlay) {
             accessibilityOverlayWindows.add(window);
             roleAssigned = true;
           }

--- a/utils/src/main/java/com/google/android/accessibility/utils/accessibilitybutton/AccessibilityButtonMonitor.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/accessibilitybutton/AccessibilityButtonMonitor.java
@@ -308,14 +308,7 @@ public class AccessibilityButtonMonitor {
           }
           break;
         case MSG_CONFIRM_BUTTON_SUPPORTABILITY_DELAYED:
-          boolean isAvailable;
-          if (BuildVersionUtils.isAtLeastOMR1()) {
-            isAvailable = AccessibilityManager.isAccessibilityButtonSupported();
-          } else {
-            isAvailable =
-                AccessibilityServiceCompatUtils.isAccessibilityButtonAvailableCompat(
-                    parent.mService.getAccessibilityButtonController());
-          }
+          boolean isAvailable = AccessibilityManager.isAccessibilityButtonSupported();
           parent.mButtonState = isAvailable ? SUPPORTED : NOT_SUPPORTED;
           if (!mHasNotifiedSupportability) {
             LogUtils.d(

--- a/utils/src/main/java/com/google/android/accessibility/utils/output/FeedbackController.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/output/FeedbackController.java
@@ -41,10 +41,7 @@ public class FeedbackController {
   private static final String TAG = "FeedbackController";
 
   /** Default stream for audio feedback. */
-  public static final int DEFAULT_STREAM =
-      BuildVersionUtils.isAtLeastO()
-          ? AudioManager.STREAM_ACCESSIBILITY
-          : AudioManager.STREAM_MUSIC;
+  public static final int DEFAULT_STREAM = AudioManager.STREAM_ACCESSIBILITY;
 
   /** Maximum number of concurrent audio streams. */
   private static final int MAX_STREAMS = 10;

--- a/utils/src/main/java/com/google/android/accessibility/utils/output/SpeechController.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/output/SpeechController.java
@@ -27,10 +27,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public interface SpeechController {
   /** Default stream for speech output. */
-  int DEFAULT_STREAM =
-      BuildVersionUtils.isAtLeastO()
-          ? AudioManager.STREAM_ACCESSIBILITY
-          : AudioManager.STREAM_MUSIC;
+  int DEFAULT_STREAM = AudioManager.STREAM_ACCESSIBILITY;
 
   // Queue modes.
   int QUEUE_MODE_INTERRUPT = 0;

--- a/utils/src/main/java/com/google/android/accessibility/utils/output/SpeechControllerImpl.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/output/SpeechControllerImpl.java
@@ -1564,21 +1564,14 @@ public class SpeechControllerImpl implements SpeechController {
     }
 
     boolean useAudioFocus = mUseAudioFocus;
-    if (BuildVersionUtils.isAtLeastN()) {
-      List<AudioRecordingConfiguration> recordConfigurations =
-          mAudioManager.getActiveRecordingConfigurations();
-      if (recordConfigurations.size() != 0) {
-        useAudioFocus = false;
-      }
+    List<AudioRecordingConfiguration> recordConfigurations =
+        mAudioManager.getActiveRecordingConfigurations();
+    if (recordConfigurations.size() != 0) {
+      useAudioFocus = false;
     }
 
     if (useAudioFocus) {
-      if (BuildVersionUtils.isAtLeastO()) {
-        mAudioManager.requestAudioFocus(mAudioFocusRequest);
-      } else {
-        mAudioManager.requestAudioFocus(
-            mAudioFocusListener, DEFAULT_STREAM, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK);
-      }
+      mAudioManager.requestAudioFocus(mAudioFocusRequest);
     }
 
     if (mIsSpeaking) {
@@ -1606,11 +1599,7 @@ public class SpeechControllerImpl implements SpeechController {
     }
 
     if (mUseAudioFocus) {
-      if (BuildVersionUtils.isAtLeastO()) {
-        mAudioManager.abandonAudioFocusRequest(mAudioFocusRequest);
-      } else {
-        mAudioManager.abandonAudioFocus(mAudioFocusListener);
-      }
+      mAudioManager.abandonAudioFocusRequest(mAudioFocusRequest);
     }
 
     if (!mIsSpeaking) {
@@ -1985,17 +1974,14 @@ public class SpeechControllerImpl implements SpeechController {
       };
 
   @Nullable
-  private final AudioFocusRequest mAudioFocusRequest =
-      BuildVersionUtils.isAtLeastO()
-          ? new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+  private final AudioFocusRequest mAudioFocusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
               .setOnAudioFocusChangeListener(mAudioFocusListener, mHandler)
               .setAudioAttributes(
                   new AudioAttributes.Builder()
                       .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
                       .setUsage(AudioAttributes.USAGE_ASSISTANCE_ACCESSIBILITY)
                       .build())
-              .build()
-          : null;
+              .build();
 
   /** An action that should be performed before a particular utterance index starts. */
   private static class UtteranceStartAction implements Comparable<UtteranceStartAction> {

--- a/utils/src/main/java/com/google/android/accessibility/utils/traversal/DirectionalTraversalStrategy.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/traversal/DirectionalTraversalStrategy.java
@@ -72,15 +72,6 @@ public class DirectionalTraversalStrategy implements TraversalStrategy {
     mRootRectPadded.inset(fudge, fudge);
 
     processNodes(mRoot, false /* forceRefresh */);
-
-    // Before N, sometimes AccessibilityNodeInfo is not properly updated after transitions
-    // occur. This was fixed in a system framework change for N. REFERTO for context.
-    // To work-around, manually refresh AccessibilityNodeInfo if it initially
-    // looks like there's nothing to focus on.
-    if (mFocusables.isEmpty() && !BuildVersionUtils.isAtLeastN()) {
-      recycle(false /* recycleRoot */);
-      processNodes(mRoot, true /* forceRefresh */);
-    }
   }
 
   /**

--- a/utils/src/main/java/com/google/android/libraries/accessibility/utils/screencapture/AndroidManifest.xml
+++ b/utils/src/main/java/com/google/android/libraries/accessibility/utils/screencapture/AndroidManifest.xml
@@ -4,7 +4,7 @@
     android:versionName="1.0.0" >
 
     <uses-sdk
-        android:minSdkVersion="26"
+        android:minSdkVersion="28"
         android:targetSdkVersion="31" />
 
     <application>


### PR DESCRIPTION
Android Oreo (API versions 26 and 27) are unsupported (security), thus We don't need to maintain old code (and tons of checks / hacks) for unsupported versions.