### PR TITLE
Do not show onboarding when lock task mode is enabled

### DIFF
--- a/talkback/src/main/java/com/google/android/accessibility/talkback/training/OnboardingInitiator.java
+++ b/talkback/src/main/java/com/google/android/accessibility/talkback/training/OnboardingInitiator.java
@@ -20,12 +20,15 @@ import static com.google.android.accessibility.talkback.trainingcommon.TrainingC
 import static com.google.android.accessibility.talkback.trainingcommon.TrainingConfig.TrainingId.TRAINING_ID_ON_BOARDING_TALKBACK;
 import static com.google.android.accessibility.talkback.trainingcommon.TrainingConfig.TrainingId.TRAINING_ID_ON_BOARDING_TALKBACK_WITHOUT_DESCRIBE_IMAGE;
 
+import android.app.ActivityManager;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
+import android.util.Log;
+
 import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.accessibility.talkback.R;
@@ -78,7 +81,7 @@ public class OnboardingInitiator {
    */
   public static void showOnboardingIfNecessary(Context context) {
     FormFactorUtils formFactorUtils = FormFactorUtils.getInstance();
-    if (formFactorUtils.isAndroidTv() || formFactorUtils.isAndroidWear()) {
+    if (formFactorUtils.isAndroidTv() || formFactorUtils.isAndroidWear() || isInLockTaskMode(context)) {
       return;
     }
 
@@ -116,6 +119,13 @@ public class OnboardingInitiator {
       context.startActivity(createOnboardingIntent(context, /* showExitBanner= */ true));
       markOnboardingForNewFeaturesAsShown(prefs, context);
     }
+  }
+
+  /** Typically Kiosk device use Lock Task mode. If enabled assume the device is a Kiosk device */
+  private static boolean isInLockTaskMode(Context context) {
+    ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+    Log.i("DEBUG", "activityManager.getLockTaskModeState() " + activityManager.getLockTaskModeState());
+    return activityManager.getLockTaskModeState() != ActivityManager.LOCK_TASK_MODE_NONE;
   }
 
   private static boolean hasOnboardingForMultiFingerGestureSupportBeenShown(


### PR DESCRIPTION
I have a Kiosk device that business have sitting on the counter.  The device has a totally custom home UI and users are not allowed to open system settings. Talkback is enabled programmatically and we assume that anyone coming to the business is familiar with services like Talkback. So, we want to skip the onboarding. We are using LockTask mode to control what apps are accessible in production. 

Since TV and wear are skipped would it be reasonable to assume Lock Task been enabled should alway skip onboarding?